### PR TITLE
Fix mimi to handle executable with arguments

### DIFF
--- a/xdg-open
+++ b/xdg-open
@@ -98,6 +98,8 @@ if [[ "$arg" =~ ^([a-zA-Z]+): ]]; then
     fi
 fi
 
+# executable with arguments
+[[ ! "$mime" ]] && [[ -x "$1" ]] && mime="$(file -b --mime-type "$1")"
 
 # application mime is specific
 [[ "$mime" =~ ^(audio|image|text|video)/ ]] && general_mime="${BASH_REMATCH[1]}/"


### PR DESCRIPTION
Hello,
I want to be able to pass executable with arguments to xdg-open, right now mimi can't guess right the file type.

For example I want to be able to do this:
`/usr/bin/xdg-open /path/to/executable --arguments 'foo'`

This commit fixes mimi to check if the first argument is executable and run `file` only for it.
