### PR TITLE
Recognize html file url with #section suffix

### DIFF
--- a/xdg-open
+++ b/xdg-open
@@ -64,6 +64,12 @@ protocol=''
 mime=''
 general_mime=''
 
+# fix file://.html#section
+if [[ "$arg" =~ ^file://([^#]*\.html)#.*$ ]]; then
+  protocol=file
+  mime=text/html
+  ext=html
+
 # fix file://
 if [[ "$arg" =~ ^file://(.*)$ ]]; then
 	# strip file://


### PR DESCRIPTION
Fix matching urls like `file:///home/amos/share/doc/fish/commands.html#commandline`